### PR TITLE
Add Search Filter Boxes to Lists

### DIFF
--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -75,6 +75,7 @@ function cmb2_attached_posts_fields_render( $field, $escaped_value, $object_id, 
 	// Open our retrieved, or found posts, list
 	echo '<div class="retrieved-wrap column-wrap">';
 	echo '<h4 class="attached-posts-section">' . sprintf( __( 'Available %s', 'cmb' ), $attached_post_type->labels->name ) . '</h4>';
+	echo '<div class="search-wrap"><input type="text" placeholder="Search for ' . sprintf( __( '%s', 'cmb' ), $attached_post_type->labels->name ) . '" class="regular-text search" name="available_search" id="available_search" /></div>';
 	echo '<ul class="retrieved connected">';
 
 	// Loop through our posts as list items
@@ -101,6 +102,7 @@ function cmb2_attached_posts_fields_render( $field, $escaped_value, $object_id, 
 	// Open our attached posts list
 	echo '<div class="attached-wrap column-wrap">';
 	echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), $attached_post_type->labels->name ) . '</h4>';
+	echo '<div class="search-wrap"><input type="text" placeholder="Search for ' . sprintf( __( '%s', 'cmb' ), $attached_post_type->labels->name ) . '" class="regular-text search" name="attached_search" id="attached_search" /></div>';
 	echo '<ul class="attached connected">';
 
 	// If we have any posts saved already, display them

--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -51,7 +51,10 @@ function cmb2_attached_posts_fields_render( $field, $escaped_value, $object_id, 
 		'orderby'			=> 'name',
 		'order'				=> 'ASC',
 	) );
-	
+
+	// Check 'filter' setting
+	$use_filter_boxes = $field->options( 'filter_boxes' );
+
 	// Get post type object for attached post type
 	$attached_post_type = get_post_type_object( $args['post_type'] );
 
@@ -75,7 +78,9 @@ function cmb2_attached_posts_fields_render( $field, $escaped_value, $object_id, 
 	// Open our retrieved, or found posts, list
 	echo '<div class="retrieved-wrap column-wrap">';
 	echo '<h4 class="attached-posts-section">' . sprintf( __( 'Available %s', 'cmb' ), $attached_post_type->labels->name ) . '</h4>';
-	echo '<div class="search-wrap"><input type="text" placeholder="Search for ' . sprintf( __( '%s', 'cmb' ), $attached_post_type->labels->name ) . '" class="regular-text search" name="available_search" id="available_search" /></div>';
+	if ( $use_filter_boxes ) {
+		echo '<div class="search-wrap"><input type="text" placeholder="Search for ' . sprintf( __( '%s', 'cmb' ), $attached_post_type->labels->name ) . '" class="regular-text search" name="available_search" id="available_search" /></div>';
+	}
 	echo '<ul class="retrieved connected">';
 
 	// Loop through our posts as list items
@@ -102,7 +107,9 @@ function cmb2_attached_posts_fields_render( $field, $escaped_value, $object_id, 
 	// Open our attached posts list
 	echo '<div class="attached-wrap column-wrap">';
 	echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), $attached_post_type->labels->name ) . '</h4>';
-	echo '<div class="search-wrap"><input type="text" placeholder="Search for ' . sprintf( __( '%s', 'cmb' ), $attached_post_type->labels->name ) . '" class="regular-text search" name="attached_search" id="attached_search" /></div>';
+	if ( $use_filter_boxes ) {
+		echo '<div class="search-wrap"><input type="text" placeholder="Search for ' . sprintf( __( '%s', 'cmb' ), $attached_post_type->labels->name ) . '" class="regular-text search" name="attached_search" id="attached_search" /></div>';
+	}
 	echo '<ul class="attached connected">';
 
 	// If we have any posts saved already, display them

--- a/css/attached-posts-admin.css
+++ b/css/attached-posts-admin.css
@@ -28,6 +28,10 @@
 	margin-bottom: 5px;
 }
 
+.cmb-type-custom-attached-posts .search-wrap {
+	margin-bottom: 5px;
+}
+
 .cmb-type-custom-attached-posts .connected {
 	background: #F4F4F4;
 	cursor: pointer;

--- a/js/attached-posts.js
+++ b/js/attached-posts.js
@@ -39,8 +39,11 @@ window.CMBAP = window.CMBAP || (function(window, document, $, undefined) {
 			// Add posts when the plus icon is clicked
 			.on( 'click', '.attached-posts-wrap .retrieved .add-remove', app.addPostToColumn )
 			// Remove posts when the minus icon is clicked
-			.on( 'click', '.attached-posts-wrap .attached .add-remove', app.removePostFromColumn );
+			.on( 'click', '.attached-posts-wrap .attached .add-remove', app.removePostFromColumn )
+			// Listen for search events
+			.on( 'keyup', '.attached-posts-wrap input.search', app.handleSearch );
 
+		
 	};
 
 	// Clone our dragged item
@@ -146,6 +149,23 @@ window.CMBAP = window.CMBAP || (function(window, document, $, undefined) {
 	// Replace the plus icon in the attached posts column
 	app.replacePlusIcon = function() {
 		$( '.attached li .dashicons.dashicons-plus' ).removeClass( 'dashicons-plus' ).addClass( 'dashicons-minus' );
+	};
+
+	// Handle searching available list
+	app.handleSearch = function( e ) {
+		var searchQuery = $(e.target).val().toLowerCase(),
+			list = $(e.target).closest( '.column-wrap' ).find( 'ul.connected li' );
+
+		list.each( function() {
+			var el = $(this),
+				elText = el.text().toLowerCase();
+
+			if ( elText.search( searchQuery ) > -1 ) {
+				el.show();
+			} else {
+				el.hide();
+			}
+		} );
 	};
 
 	jQuery(document).ready( app.init );


### PR DESCRIPTION
I need the functionality of both plugins (https://github.com/WebDevStudios/CMB2-Post-Search-field and https://github.com/WebDevStudios/cmb2-attached-posts). I need to list more than just IDs, but also be able to easily search/find posts from the list.

I've added a simple search box to each of the lists (available and attached), which loops through the <li> tags to match the value entered in the search box.

I've also added an option to toggle the filter boxes. By default the filter boxes are off.