### PR TITLE
fix attached posts for multiple instances

### DIFF
--- a/js/attached-posts.js
+++ b/js/attached-posts.js
@@ -58,7 +58,7 @@ window.CMBAP = window.CMBAP || (function(window, document, $, undefined) {
 		// Add the 'added' class to our retrieved column when clicked
 		app.$.retrievedPosts.find( '[data-id="'+ itemID +'"]' ).addClass( 'added' );
 
-		item.clone().appendTo( app.$.attachedPosts );
+		item.clone().appendTo( $( '.attached', $wrap ) );
 
 		app.resetAttachedListItems( $wrap );
 	};


### PR DESCRIPTION
When you have multiple instances of this custom special field and you drag&drop items from right to left, they are added to every instance.