### PR TITLE
fix trying to get property of non-object errors when using multiple post types

### DIFF
--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -57,9 +57,11 @@ class WDS_CMB2_Attached_Posts_Field {
 			$post_type_labels[] = $attached_post_type->labels->name;
 		}
 
+		$post_type_labels = implode( '/', $post_type_labels );
+
 		// Check 'filter' setting
 		$filter_boxes = $field->options( 'filter_boxes' )
-			? '<div class="search-wrap"><input type="text" placeholder="' . sprintf( __( 'Filter %s', 'cmb' ), implode( '/', $post_type_labels ) ) . '" class="regular-text search" name="%s" /></div>'
+			? '<div class="search-wrap"><input type="text" placeholder="' . sprintf( __( 'Filter %s', 'cmb' ), $post_type_labels ) . '" class="regular-text search" name="%s" /></div>'
 			: '';
 
 		// Get our posts
@@ -81,7 +83,7 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		// Open our retrieved, or found posts, list
 		echo '<div class="retrieved-wrap column-wrap">';
-		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Available %s', 'cmb' ), implode( '/', $post_type_labels ) ) . '</h4>';
+		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Available %s', 'cmb' ), $post_type_labels ) . '</h4>';
 
 		// Set .has_thumbnail
 		$has_thumbnail = $field->options( 'show_thumbnails' ) ? ' has-thumbnails' : '';
@@ -118,7 +120,7 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		// Open our attached posts list
 		echo '<div class="attached-wrap column-wrap">';
-		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), implode( '/', $post_type_labels ) ) . '</h4>';
+		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), $post_type_labels ) . '</h4>';
 
 		if ( $filter_boxes ) {
 			printf( $filter_boxes, 'attached-search' );

--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -43,12 +43,23 @@ class WDS_CMB2_Attached_Posts_Field {
 			'order'				=> 'ASC',
 		) );
 
-		// Get post type object for attached post type
-		$attached_post_type = get_post_type_object( $args['post_type'] );
+		// loop through post types to get labels for all
+		$post_type_labels = array();
+		foreach ( (array) $args['post_type'] as $post_type ) {
+			// Get post type object for attached post type
+			$attached_post_type = get_post_type_object( $post_type );
+
+			// continue if we don't have a label for the post type
+			if ( ! $attached_post_type || ! isset( $attached_post_type->labels->name ) ) {
+				continue;
+			}
+
+			$post_type_labels[] = $attached_post_type->labels->name;
+		}
 
 		// Check 'filter' setting
 		$filter_boxes = $field->options( 'filter_boxes' )
-			? '<div class="search-wrap"><input type="text" placeholder="' . sprintf( __( 'Filter %s', 'cmb' ), $attached_post_type->labels->name ) . '" class="regular-text search" name="%s" /></div>'
+			? '<div class="search-wrap"><input type="text" placeholder="' . sprintf( __( 'Filter %s', 'cmb' ), implode( '/', $post_type_labels ) ) . '" class="regular-text search" name="%s" /></div>'
 			: '';
 
 		// Get our posts

--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -81,7 +81,7 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		// Open our retrieved, or found posts, list
 		echo '<div class="retrieved-wrap column-wrap">';
-		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Available %s', 'cmb' ), $attached_post_type->labels->name ) . '</h4>';
+		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Available %s', 'cmb' ), implode( '/', $post_type_labels ) ) . '</h4>';
 
 		// Set .has_thumbnail
 		$has_thumbnail = $field->options( 'show_thumbnails' ) ? ' has-thumbnails' : '';
@@ -118,7 +118,7 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		// Open our attached posts list
 		echo '<div class="attached-wrap column-wrap">';
-		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), $attached_post_type->labels->name ) . '</h4>';
+		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), implode( '/', $post_type_labels ) ) . '</h4>';
 
 		if ( $filter_boxes ) {
 			printf( $filter_boxes, 'attached-search' );


### PR DESCRIPTION
The errors/warnings below occur when passing in an array of post types.  Typecasting $args['post_type'] to an array and looping through attached post types fixes those errors.

[01-Jun-2015 15:11:28 UTC] PHP Warning:  Illegal offset type in isset or empty in /www/gs/wp-includes/post.php on line 1160
[01-Jun-2015 15:11:28 UTC] PHP Notice:  Trying to get property of non-object in /www/gs/wp-content/plugins/cmb2-attached-posts/cmb2-attached-posts-field.php on line 51
[01-Jun-2015 15:11:28 UTC] PHP Notice:  Trying to get property of non-object in /www/gs/wp-content/plugins/cmb2-attached-posts/cmb2-attached-posts-field.php on line 51
[01-Jun-2015 15:11:28 UTC] PHP Notice:  Trying to get property of non-object in /www/gs/wp-content/plugins/cmb2-attached-posts/cmb2-attached-posts-field.php on line 73
[01-Jun-2015 15:11:28 UTC] PHP Notice:  Trying to get property of non-object in /www/gs/wp-content/plugins/cmb2-attached-posts/cmb2-attached-posts-field.php on line 73
[01-Jun-2015 15:11:28 UTC] PHP Notice:  Trying to get property of non-object in /www/gs/wp-content/plugins/cmb2-attached-posts/cmb2-attached-posts-field.php on line 110
[01-Jun-2015 15:11:28 UTC] PHP Notice:  Trying to get property of non-object in /www/gs/wp-content/plugins/cmb2-attached-posts/cmb2-attached-posts-field.php on line 110