### PR TITLE
added option to hide the selected posts from the main list when added

### DIFF
--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -87,12 +87,13 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		// Set .has_thumbnail
 		$has_thumbnail = $field->options( 'show_thumbnails' ) ? ' has-thumbnails' : '';
+		$hide_selected = $field->options( 'hide_selected' ) ? ' hide-selected' : '';
 
 		if ( $filter_boxes ) {
 			printf( $filter_boxes, 'available-search' );
 		}
 
-		echo '<ul class="retrieved connected', $has_thumbnail ,'">';
+		echo '<ul class="retrieved connected' . $has_thumbnail . $hide_selected . '">';
 
 		// Loop through our posts as list items
 		foreach ( $posts as $post ) {

--- a/css/attached-posts-admin.css
+++ b/css/attached-posts-admin.css
@@ -97,3 +97,7 @@
 	top: 50%;
 	width: 22px;
 }
+
+ul.hide-selected li.added{
+    display: none;
+}


### PR DESCRIPTION
And Fixed: replaced the comes’s with periods to allow the has_thumbnail class to be added to UL

This simple patch allows you to add 'hide_selected' => true, to the options

```
'options' => array(
				'show_thumbnails' => true, // Show thumbnails on the left
				'hide_selected' => true, // hide post in the main list if added
				'filter_boxes'    => true, // Show a text box for filtering the results
				)
```