### PR TITLE
Fix post type labels loop bug

### DIFF
--- a/init.php
+++ b/init.php
@@ -67,8 +67,9 @@ class WDS_CMB2_Attached_Posts_Field {
 				}
 
 				$post_type_labels[] = $attached_post_type->labels->name;
-				$post_type_labels = implode( '/', $post_type_labels );
 			}
+			$post_type_labels = implode( '/', $post_type_labels );
+			
 		} else {
 			// Setup our args
 			$args = wp_parse_args( (array) $field->options( 'query_args' ), array(


### PR DESCRIPTION
In case you have multiple post types set the loop will fail because the array is imploded in the first loop.