### PR TITLE
Clearfix for posts with thumbnails and a little improvement

### DIFF
--- a/css/attached-posts-admin.css
+++ b/css/attached-posts-admin.css
@@ -39,10 +39,15 @@
 }
 
 .cmb-type-custom-attached-posts .has-thumbnails.connected {
-	height: 600px;
+	height: 30em;
 }
 
 .cmb-type-custom-attached-posts .has-thumbnails li {
+	clear: both;
+}
+.cmb-type-custom-attached-posts .has-thumbnails li::after {
+	content: ' ';
+	display: block;
 	clear: both;
 }
 


### PR DESCRIPTION
I added a clearfix for posts with a thumbnail. Now the rows will display correctly.
I also set the height of the list from 600px to 30em. I disliked how long the list was and i also don't linke pixel units (which is a personal flavour).