### PR TITLE
Fix an issue when a post is deleted but still present in the meta.

### DIFF
--- a/init.php
+++ b/init.php
@@ -329,7 +329,7 @@ class WDS_CMB2_Attached_Posts_Field {
 	 * @return int            The object ID.
 	 */
 	public function get_id( $object ) {
-		return $object->ID;
+        return isset($object->ID) ? $object->ID : false;
 	}
 
 	/**


### PR DESCRIPTION
This causes the deleted items id not to be included in the textarea therefore stopping the errors being spat out.