### PR TITLE
Adding support for limiting the amount of posts that can be sele…

### DIFF
--- a/init.php
+++ b/init.php
@@ -179,7 +179,7 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		// Open our attached posts list
 		echo '<div class="attached-wrap column-wrap">';
-		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), $post_type_labels ) . '</h4>';
+		echo '<h4 class="attached-posts-section">' . sprintf( __( 'Attached %s', 'cmb' ), $post_type_labels ) . '<span class="attached-posts-remaining hidden">(<span class="attached-posts-remaining-number"></span> remaining)</span></span></h4>';
 
 		if ( $filter_boxes ) {
 			printf( $filter_boxes, 'attached-search' );

--- a/js/attached-posts.js
+++ b/js/attached-posts.js
@@ -14,6 +14,46 @@ window.CMBAP = window.CMBAP || {};
 		app.doType           = $wrap.find( '.object-label' ).length;
 	};
 
+	// Helper function to determine whteher we have exceeded our limit or not.
+	app._hasExceeded = function ($wrap) {
+		var $input = app.getPostIdsInput($wrap);
+		var maxItems = $input.data('max-items');
+		var currentNumberItems = app.getPostIdsVal($input).length;
+
+		return (typeof maxItems !== "undefined") && currentNumberItems >= maxItems;
+	};
+
+	// Make sure we cannot attach more posts than we would like.
+	app.updateReadOnly = function ($wrap) {
+
+		// If we have exceeded our limit, then ensure the user cannot attach more items.
+		// If we haven't, make sure the user can attach items.
+		if (app._hasExceeded($wrap)) {
+			// Also ensure items aren't draggable
+			// @see https://stackoverflow.com/questions/1324044/how-do-i-disable-a-jquery-ui-draggable
+			// app.$retrievedPosts().draggable('disable');
+			$wrap.find('.attached').droppable("option", "accept", ".doesnotexist");
+		} else {
+			// app.$retrievedPosts().draggable('enable');
+			$wrap.find('.attached').droppable("option", "accept", ".retrieved li");
+		}
+	};
+
+	app.updateRemaining = function ($wrap) {
+		var $input = app.getPostIdsInput($wrap);
+		var currentNumberItems = app.getPostIdsVal($input).length;
+		var maxItems = $input.data('max-items');
+		var $remainingLabel = $wrap.find('.attached-posts-remaining');
+		var $remainingNumberLabel = $remainingLabel.find('.attached-posts-remaining-number');
+		var remainingNumber = 0;
+		if (typeof maxItems !== "undefined") {
+			// How many can we add?
+			remainingNumber = maxItems - currentNumberItems;
+			// Show the label and update the number inside
+			$remainingLabel.removeClass("hidden");
+			$remainingNumberLabel.html(remainingNumber);
+		}
+	};
 	app.init = function() {
 		app.cache();
 
@@ -22,6 +62,14 @@ window.CMBAP = window.CMBAP || {};
 
 		// Allow the right list to be droppable and sortable
 		app.makeDroppable();
+
+
+		$(".attached-posts-wrap").each(function () {
+			// Update whether or not the lists should be editable by the user. This is usually when a user has attached too many items.
+			app.updateReadOnly($(this));
+
+			app.updateRemaining($(this))
+		});
 
 		$( '.cmb2-wrap > .cmb2-metabox' )
 			// Add posts when the plus icon is clicked
@@ -75,6 +123,8 @@ window.CMBAP = window.CMBAP || {};
 		item.clone().appendTo( $wrap.find( '.attached' ) );
 
 		app.resetAttachedListItems( $wrap );
+		app.updateRemaining($wrap);
+
 	};
 
 	// Add the items when the plus icon is clicked
@@ -86,6 +136,10 @@ window.CMBAP = window.CMBAP || {};
 	app.moveRowToAttached = function( $li ) {
 		var itemID = $li.data( 'id' );
 		var $wrap  = $li.parents( '.attached-posts-wrap' );
+
+		if (app._hasExceeded($wrap)) {
+			return;
+		}
 
 		if ( $li.hasClass( 'added' ) ) {
 			return;
@@ -103,6 +157,8 @@ window.CMBAP = window.CMBAP || {};
 		$wrap.find( '.attached' ).append( $li.clone() );
 
 		app.resetAttachedListItems( $wrap );
+		app.updateReadOnly($wrap);
+		app.updateRemaining($wrap);
 	};
 
 	// Remove items from our attached list when the minus icon is clicked
@@ -123,6 +179,8 @@ window.CMBAP = window.CMBAP || {};
 		$wrap.find('.retrieved li[data-id="' + itemID +'"]').removeClass('added');
 
 		app.resetAttachedListItems( $wrap );
+		app.updateReadOnly($wrap);
+		app.updateRemaining($wrap);
 	};
 
 	app.inputHasId = function( $wrap, itemID ) {


### PR DESCRIPTION
Here's a PR that will introduce the functionality to specify a max amount of posts to be attached.
The user won't be able to add more than X posts into your metafield. 
To specify how many items are allowed, add a data attribute "max-items" to your metafield
If the "max-items" field isn't specified, then unlimited items are allowed (as it would without this change).
For example:
`````
/**
 * Define the metabox and field configurations.
 *
 * @param  array $meta_boxes
 * @return array
 */
function cmb2_attached_posts_field_metaboxes_example() {
	$example_meta = new_cmb2_box( array(
		'id'           => 'cmb2_attached_posts_field',
		'title'        => __( 'Attached Posts', 'yourtextdomain' ),
		'object_types' => array( 'page' ), // Post type
		'context'      => 'normal',
		'priority'     => 'high',
		'show_names'   => false, // Show field names on the left
	) );
	$example_meta->add_field( array(
		'name'    => __( 'Attached Posts', 'yourtextdomain' ),
		'desc'    => __( 'Drag posts from the left column to the right column to attach them to this page.<br />You may rearrange the order of the posts in the right column by dragging and dropping.', 'yourtextdomain' ),
		'id'      => 'attached_cmb2_attached_posts',
		'type'    => 'custom_attached_posts',
		'column'  => true, // Output in the admin post-listing as a custom column. https://github.com/CMB2/CMB2/wiki/Field-Parameters#column
		'options' => array(
			'show_thumbnails' => true, // Show thumbnails on the left
			'filter_boxes'    => true, // Show a text box for filtering the results
			'query_args'      => array(
				'posts_per_page' => 10,
				'post_type'      => 'page',
			), // override the get_posts args
		),
		attributes' => array(
		   'data-max-items' => 3, //change the value here to how many posts may be attached.
		),
	) );
````