### PR TITLE
Added message when no posts are found

### DIFF
--- a/init.php
+++ b/init.php
@@ -131,6 +131,7 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		// If there are no posts found, just stop
 		if ( empty( $objects ) ) {
+			echo apply_filters( 'cmb2_attached_posts_field_no_items_found', sprintf( '<p><em>%s</em></p>', __( 'No items found.' ) ) );
 			return;
 		}
 


### PR DESCRIPTION
When no posts are found, the rendered field is completely blank. This message, with related filter, can be useful to notify the user of the missing posts.