### PR TITLE
Quality of Life / Modernization

### DIFF
--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -1,11 +1,10 @@
 <?php
 /**
- * Plugin Name: CMB2 Field Type: Attached Posts
+ * Plugin Name: FORKED -- CMB2 Field Type: Attached Posts
  * Plugin URI: https://github.com/WebDevStudios/cmb2-attached-posts
  * Description: Attached posts field type for CMB2.
- * Version: 1.2.7
- * Author: WebDevStudios
- * Author URI: http://webdevstudios.com
+ * Version: 2.1
+ * Author: WebDevStudios, Ipstenu
  * License: GPLv2+
  */
 
@@ -18,8 +17,6 @@
  * @package   WDS_CMB2_Attached_Posts_Field
  * @author    WebDevStudios <contact@webdevstudios.com>
  * @copyright 2016 WebDevStudios <contact@webdevstudios.com>
- * @license   GPL-2.0+
- * @version   1.2.7
  * @link      https://github.com/WebDevStudios/cmb2-attached-posts
  * @since     1.2.3
  */
@@ -68,7 +65,7 @@ if ( ! class_exists( 'WDS_CMB2_Attached_Posts_Field_127', false ) ) {
 		 * @var   string
 		 * @since 1.2.3
 		 */
-		const VERSION = '1.2.7';
+		const VERSION = '2.1';
 
 		/**
 		 * Current version hook priority.
@@ -155,5 +152,5 @@ if ( ! class_exists( 'WDS_CMB2_Attached_Posts_Field_127', false ) ) {
 	}
 
 	// Kick it off.
-	new WDS_CMB2_Attached_Posts_Field_127;
+	new WDS_CMB2_Attached_Posts_Field_127();
 }

--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: FORKED -- CMB2 Field Type: Attached Posts
+ * Plugin Name: CMB2 Field Type: Attached Posts
  * Plugin URI: https://github.com/WebDevStudios/cmb2-attached-posts
  * Description: Attached posts field type for CMB2.
  * Version: 2.1

--- a/cmb2-attached-posts-field.php
+++ b/cmb2-attached-posts-field.php
@@ -43,7 +43,7 @@
  * Loader versioning: http://jtsternberg.github.io/wp-lib-loader/
  */
 
-if ( ! class_exists( 'WDS_CMB2_Attached_Posts_Field_127', false ) ) {
+if ( ! class_exists( 'WDS_CMB2_Attached_Posts_Field_210', false ) ) {
 
 	/**
 	 * Versioned loader class-name
@@ -54,11 +54,11 @@ if ( ! class_exists( 'WDS_CMB2_Attached_Posts_Field_127', false ) ) {
 	 * @package  WDS_CMB2_Attached_Posts_Field
 	 * @author   WebDevStudios <contact@webdevstudios.com>
 	 * @license  GPL-2.0+
-	 * @version  1.2.7
+	 * @version  2.1.0
 	 * @link     https://github.com/WebDevStudios/cmb2-attached-posts
 	 * @since    1.2.3
 	 */
-	class WDS_CMB2_Attached_Posts_Field_127 {
+	class WDS_CMB2_Attached_Posts_Field_210 {
 
 		/**
 		 * WDS_CMB2_Attached_Posts_Field version number
@@ -152,5 +152,5 @@ if ( ! class_exists( 'WDS_CMB2_Attached_Posts_Field_127', false ) ) {
 	}
 
 	// Kick it off.
-	new WDS_CMB2_Attached_Posts_Field_127();
+	new WDS_CMB2_Attached_Posts_Field_210();
 }

--- a/init.php
+++ b/init.php
@@ -74,6 +74,7 @@ class WDS_CMB2_Attached_Posts_Field {
 
 		$query_args  = (array) $this->field->options( 'query_args' );
 		$query_users = $this->field->options( 'query_users' );
+		$post_status = array( 'publish' );
 
 		if ( ! $query_users ) {
 
@@ -83,7 +84,7 @@ class WDS_CMB2_Attached_Posts_Field {
 				array(
 					'post_type'      => 'post',
 					'posts_per_page' => 100,
-					'post_status'    => array( 'publish', 'pending', 'draft', 'future', 'private', 'inherit' ),
+					'post_status'    => apply_filters( 'cmb2_attached_posts_status_filter', $post_status ),
 				)
 			);
 
@@ -378,7 +379,7 @@ class WDS_CMB2_Attached_Posts_Field {
 		$post = get_post( $object );
 		// Initial Title
 		$title = $this->field->options( 'query_users' ) ? $object->data->display_name : get_the_title( $post->ID );
-		$title = apply_filters( 'cmb2_attached_posts_filter_title', $post->ID, $title );
+		$title = apply_filters( 'cmb2_attached_posts_title_filter', $post->ID, $title );
 
 		return $title . $additional;
 	}
@@ -731,7 +732,7 @@ class WDS_CMB2_Attached_Posts_Field {
 			$return .= '<ol>';
 			foreach ( (array) $posts as $id => $post ) {
 
-				$title = apply_filters( 'cmb2_attached_posts_filter_title', $id, $post['title'] );
+				$title = apply_filters( 'cmb2_attached_posts_title_filter', $id, $post['title'] );
 
 				$return .= sprintf(
 					'<li id="attached-%d"><a href="%s">%s</a></li>',

--- a/init.php
+++ b/init.php
@@ -83,7 +83,7 @@ class WDS_CMB2_Attached_Posts_Field {
 				$query_args,
 				array(
 					'post_type'      => 'post',
-					'posts_per_page' => 100,
+					'posts_per_page' => apply_filters( 'cmb2_attached_posts_per_page_filter', 50 ),
 					'post_status'    => apply_filters( 'cmb2_attached_posts_status_filter', $post_status ),
 				)
 			);

--- a/init.php
+++ b/init.php
@@ -384,7 +384,7 @@ class WDS_CMB2_Attached_Posts_Field {
 		$title = $this->field->options( 'query_users' ) ? $object->data->display_name : get_the_title( $post->ID );
 		$title = apply_filters( 'cmb2_attached_posts_title_filter', $post->ID, $title );
 
-		return $title . $additional;
+		return $title;
 	}
 
 	/**

--- a/init.php
+++ b/init.php
@@ -382,7 +382,7 @@ class WDS_CMB2_Attached_Posts_Field {
 		$post = get_post( $object );
 		// Initial Title
 		$title = $this->field->options( 'query_users' ) ? $object->data->display_name : get_the_title( $post->ID );
-		$title = apply_filters( 'cmb2_attached_posts_title_filter', $post->ID, $title );
+		$title = apply_filters( 'cmb2_attached_posts_title_filter', $title, $post->ID );
 
 		return $title;
 	}
@@ -735,7 +735,7 @@ class WDS_CMB2_Attached_Posts_Field {
 			$return .= '<ol>';
 			foreach ( (array) $posts as $id => $post ) {
 
-				$title = apply_filters( 'cmb2_attached_posts_title_filter', $id, $post['title'] );
+				$title = apply_filters( 'cmb2_attached_posts_title_filter', $post['title'], $id );
 
 				$return .= sprintf(
 					'<li id="attached-%d"><a href="%s">%s</a></li>',

--- a/init.php
+++ b/init.php
@@ -321,14 +321,17 @@ class WDS_CMB2_Attached_Posts_Field {
 	 * @return void
 	 */
 	public function list_item( $object, $li_class, $icon_class = 'dashicons-plus' ) {
-		echo '<li 
-			data-id="' . esc_attr( $this->get_id( $object ) ) . '" 
-			class="' . esc_attr( $li_class ) . '" target="_blank">'
-			. esc_html( $this->get_thumb( $object ) ) . '
-			<a title="Edit" href="' . esc_url( $this->get_edit_link( $object ) ) . '">'
-			. esc_html( $this->get_title( $object ) ) . '</a>
-			' . esc_html( $this->get_object_label( $object ) ) . '<span class="dashicons '
-			. esc_attr( $icon_class ) . ' add-remove"></span></li>';
+		// Build our list item
+		printf(
+			'<li data-id="%1$d" class="%2$s" target="_blank">%3$s<a title="' . esc_html( __( 'Edit' ) ) . '" href="%4$s">%5$s</a>%6$s<span class="dashicons %7$s add-remove"></span></li>',
+			esc_attr( $this->get_id( $object ) ),
+			esc_attr( $li_class ),
+			esc_html( $this->get_thumb( $object ) ),
+			esc_url( $this->get_edit_link( $object ) ),
+			esc_html( $this->get_title( $object ) ),
+			esc_html( $this->get_object_label( $object ) ),
+			esc_attr( $icon_class )
+		);
 	}
 
 	/**


### PR DESCRIPTION
This pull is basically bringing a LOT of the existing pulls up to modern speed, slapping it around with PHPCS and formatting, and adding in things I needed if I didn't want to hardcode in everything.

It runs live on lezwatchtv.com and is what powers our connections of characters to actors/shows.

## Overview

1. Bring (most of) the code to modern standards per PHPCS
2. Improve inline documentation (spelling etc)
3. Added new filters
4. `cmb2_attached_posts_objects` filter (from https://github.com/CMB2/cmb2-attached-posts/pull/58 - props @njeffers )
5. Change lightbox 'title' based on post-types (i.e. 'Search Custom Post Named Bob' vs 'Find Posts and Pages')
6. Display errors instead of failing silently if no posts are found
7. support for limiting the amount of posts that can be selected (based on https://github.com/CMB2/cmb2-attached-posts/pull/52 - props @d79 )
8. Fix for deleted posts borking meta (from https://github.com/CMB2/cmb2-attached-posts/pull/49/ - props @jrmd )
9. Allow multiple metaboxes on one page (from https://github.com/CMB2/cmb2-attached-posts/pull/41 - props @cggit )
10. Change enqueue URLs to be flexible for weirdos who put the library inside a massive plugin/theme instead of as a separate plugin

## New Filters

`cmb2_attached_posts_title_filter` - allows the display title of the post to be altered

example:

```
add_filter( 'cmb2_attached_posts_title_filter', 'YOURPREFIX_cmb_filter_title_attached_posts', 10, 2 );

function YOURPREFIX_cmb_filter_title_attached_posts( $post_title, $post_id ) {
	$additional = array();
	$status     = get_post_status( $post_id );
	$has_meta   = get_post_meta( $post_id, 'EXAMPLE_META', true );
	if ( ! empty( $has_meta ) && $has_meta ) {
		$additional[] = 'This is extra stuff I want to show at the end of the title';
	}
	if ( ! empty( $additional ) ) {
		$post_title .= ' (' . implode( ', ', $additional ) . ')';
	}

	return $post_title;
}
```

`cmb2_attached_posts_status_filter ` - changes the post types allowed.

example:

```
add_filter( 'cmb2_attached_posts_status_filter', 'YOURPREFIX_cmb_filter_post_status_attached_posts', 10, 2 );

function YOURPREFIX_cmb_filter_post_status_attached_posts( $post_status ) {
	$post_status = array( 'publish', 'pending', 'draft', 'future', 'private', 'inherit' );
	return $post_status;
}
```

`cmb2_attached_posts_per_page_filter` - changes how many pages to search (important to me as we have a couple thousand ;) 

example:

```
add_filter( 'cmb2_attached_posts_per_page_filter', 'YOURPREFIX_cmb_filter_post_statue_attached_posts', 10, 2 );

function YOURPREFIX_cmb_filter_post_statue_attached_posts( $post_status ) {
	$post_status = array( 'publish', 'pending', 'draft', 'future', 'private', 'inherit' );
	return $post_status;
}
```